### PR TITLE
Cerberus report path configuration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,6 +42,7 @@ cerberus:
     slack_team_alias:                                    # The slack team alias to be tagged while reporting failures in the slack channel when no watcher is assigned
 
     custom_checks:                                       # Relative paths of files conataining additional user defined checks
+
 tunings:
     timeout: 60                                          # Number of seconds before requests fail
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,6 +43,8 @@ cerberus:
 
     custom_checks:                                       # Relative paths of files conataining additional user defined checks
 
+    report_path: cerberus.report                         # Path to the cerberus.report file
+
 tunings:
     timeout: 60                                          # Number of seconds before requests fail
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,9 +42,6 @@ cerberus:
     slack_team_alias:                                    # The slack team alias to be tagged while reporting failures in the slack channel when no watcher is assigned
 
     custom_checks:                                       # Relative paths of files conataining additional user defined checks
-
-    report_path: cerberus.report                         # Path to the cerberus.report file
-
 tunings:
     timeout: 60                                          # Number of seconds before requests fail
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ $ podman logs -f cerberus
 
 The go/no-go signal ( True or False ) gets published at http://`<hostname>`:8080. Note that the cerberus will only support ipv4 for the time being.
 
-**NOTE**: The report by default is generated at /root/cerberus/cerberus.report inside the container, it can be configured to a path with volume mounted in case we want to capture and keep it.
+**NOTE**: The report is generated at /tmp/cerberus-report.log inside the container, it can mounted to a directory on the host in case we want to capture it.
 
 If you want to build your own Cerberus image, see [here](https://github.com/cloud-bulldozer/cerberus/tree/master/containers/build_own_image-README.md).
 To run Cerberus on Power (ppc64le) architecture, build and run a containerized version by following the instructions given [here](https://github.com/cloud-bulldozer/cerberus/tree/master/containers/build_own_image-README.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ $ podman logs -f cerberus
 
 The go/no-go signal ( True or False ) gets published at http://`<hostname>`:8080. Note that the cerberus will only support ipv4 for the time being.
 
-**NOTE**: The report is generated at /root/cerberus/cerberus.report inside the container, it can mounted to a directory on the host in case we want to capture it.
+**NOTE**: The report by default is generated at /root/cerberus/cerberus.report inside the container, it can be configured to a path with volume mounted in case we want to capture and keep it.
 
 If you want to build your own Cerberus image, see [here](https://github.com/cloud-bulldozer/cerberus/tree/master/containers/build_own_image-README.md).
 To run Cerberus on Power (ppc64le) architecture, build and run a containerized version by following the instructions given [here](https://github.com/cloud-bulldozer/cerberus/tree/master/containers/build_own_image-README.md).

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -89,7 +89,7 @@ def main(cfg):
         prometheus_url = config["cerberus"].get("prometheus_url", "")
         prometheus_bearer_token = config["cerberus"].get("prometheus_bearer_token", "")
         custom_checks = config["cerberus"].get("custom_checks", [])
-        report_path = config["cerberus"].get("report_path", "/tmp/cerberus.report")
+        report_path = config["cerberus"].get("report_path", "cerberus.report")
         iterations = config["tunings"].get("iterations", 0)
         sleep_time = config["tunings"].get("sleep_time", 0)
         cmd_timeout = config["tunings"].get("timeout", 60)

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -89,7 +89,6 @@ def main(cfg):
         prometheus_url = config["cerberus"].get("prometheus_url", "")
         prometheus_bearer_token = config["cerberus"].get("prometheus_bearer_token", "")
         custom_checks = config["cerberus"].get("custom_checks", [])
-        report_path = config["cerberus"].get("report_path", "cerberus.report")
         iterations = config["tunings"].get("iterations", 0)
         sleep_time = config["tunings"].get("sleep_time", 0)
         cmd_timeout = config["tunings"].get("timeout", 60)
@@ -555,7 +554,7 @@ if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
-        handlers=[logging.FileHandler(report_path, mode="w"), logging.StreamHandler()],
+        handlers=[logging.FileHandler("/tmp/cerberus-report.log", mode="w"), logging.StreamHandler()],
     )
     if options.cfg is None:
         logging.error("Please check if you have passed the config")

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -89,6 +89,7 @@ def main(cfg):
         prometheus_url = config["cerberus"].get("prometheus_url", "")
         prometheus_bearer_token = config["cerberus"].get("prometheus_bearer_token", "")
         custom_checks = config["cerberus"].get("custom_checks", [])
+        report_path = config["cerberus"].get("report_path", "/tmp/cerberus.report")
         iterations = config["tunings"].get("iterations", 0)
         sleep_time = config["tunings"].get("sleep_time", 0)
         cmd_timeout = config["tunings"].get("timeout", 60)
@@ -554,7 +555,7 @@ if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
-        handlers=[logging.FileHandler("cerberus.report", mode="w"), logging.StreamHandler()],
+        handlers=[logging.FileHandler(report_path, mode="w"), logging.StreamHandler()],
     )
     if options.cfg is None:
         logging.error("Please check if you have passed the config")


### PR DESCRIPTION
### Background:
Originally the logs are write to `/root/cerberus/cerberus.report` which by default does not exist as part of the code base, nor is it editable when mounted. ~It would be ideal if the path for the logging report can be configurable to a different place where we can mount a volume to it to save the logs if needed.~

It cannot be configured based on config.yaml as that is parsed in at a later point after `logging` is setup. Thus updating the log file to `/tmp` folder to get rid of the file system permission issue.

### Changes:
- change the default log file path from  `/root/cerberus/cerberus.report` to `/tmp/cerberus-report.log`