### PR TITLE
Add support to ignore checking pods in ns

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,7 @@ cerberus:
         -    openshift-kube-scheduler
         -    openshift-ingress
         -    openshift-sdn                               # When enabled, it will check for the cluster sdn and monitor that namespace
+    watch_namespaces_ignore_pattern: [^installer*]       # Ignores pods matching the regex pattern in the namespaces specified under watch_namespaces
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
     inspect_components: False                            # Enable it only when OpenShift client is supported to run
                                                          # When enabled, cerberus collects logs, events and metrics of failed components

--- a/config/kubernetes_config.yaml
+++ b/config/kubernetes_config.yaml
@@ -9,6 +9,7 @@ cerberus:
         label: node-role.kubernetes.io/master
     watch_namespaces:                                    # List of namespaces to be monitored
         -    kube-system
+    watch_namespaces_ignore_pattern: []                  # Ignores pods matching the regex pattern in the namespaces specified under watch_namespaces
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
     inspect_components: False                            # Enable it only when OpenShift client is supported to run
                                                          # When enabled, cerberus collects logs, events and metrics of failed components

--- a/docs/config.md
+++ b/docs/config.md
@@ -37,6 +37,7 @@ cerberus:
         -    openshift-kube-scheduler
         -    openshift-ingress
         -    openshift-sdn                                   # When enabled, it will check for the cluster sdn and monitor that namespace
+    watch_namespaces_ignore_pattern: []                  # Ignores pods matching the regex pattern in the namespaces specified under watch_namespaces
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
     inspect_components: False                            # Enable it only when OpenShift client is supported to run
                                                          # When enabled, cerberus collects logs, events and metrics of failed components

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -79,6 +79,7 @@ def main(cfg):
         watch_nodes = config["cerberus"].get("watch_nodes", False)
         watch_cluster_operators = config["cerberus"].get("watch_cluster_operators", False)
         watch_namespaces = config["cerberus"].get("watch_namespaces", [])
+        watch_namespaces_ignore_pattern = config["cerberus"].get("watch_namespaces_ignore_pattern", [])
         watch_terminating_namespaces = config["cerberus"].get("watch_terminating_namespaces", True)
         watch_url_routes = config["cerberus"].get("watch_url_routes", [])
         watch_master_schedulable = config["cerberus"].get("watch_master_schedulable", {})
@@ -288,6 +289,7 @@ def main(cfg):
                         watch_namespaces,
                         repeat(failed_pods_components),
                         repeat(failed_pod_containers),
+                        repeat(watch_namespaces_ignore_pattern),
                     ),
                 )
 


### PR DESCRIPTION
This commit adds a way for user to specify a regex to ignore checking
the pods in the namespaces.

Fixes https://github.com/redhat-chaos/cerberus/issues/177.