### PR TITLE
Adding create token

### DIFF
--- a/cerberus/prometheus/client.py
+++ b/cerberus/prometheus/client.py
@@ -16,8 +16,9 @@ def initialize_prom_client(distribution, prometheus_url, prometheus_bearer_token
         prometheus_url = "https://" + url
     if distribution == "openshift" and not prometheus_bearer_token:
         prometheus_bearer_token = runcommand.invoke(
-            "oc -n openshift-monitoring sa get-token prometheus-k8s "
-            "|| oc create token -n openshift-monitoring prometheus-k8s"
+            "oc create token -n openshift-monitoring prometheus-k8s --duration=6h "
+            "|| oc sa get-token -n openshift-monitoring prometheus-k8s || "
+            "oc sa new-token -n openshift-monitoring prometheus-k8s"
         )
     if prometheus_url and prometheus_bearer_token:
         bearer = "Bearer " + prometheus_bearer_token

--- a/cerberus/prometheus/client.py
+++ b/cerberus/prometheus/client.py
@@ -16,7 +16,7 @@ def initialize_prom_client(distribution, prometheus_url, prometheus_bearer_token
         prometheus_url = "https://" + url
     if distribution == "openshift" and not prometheus_bearer_token:
         prometheus_bearer_token = runcommand.invoke(
-            "oc create token -n openshift-monitoring prometheus-k8s --duration=6h "
+            "oc create token -n openshift-monitoring prometheus-k8s --duration=12h "
             "|| oc sa get-token -n openshift-monitoring prometheus-k8s || "
             "oc sa new-token -n openshift-monitoring prometheus-k8s"
         )


### PR DESCRIPTION
Need to add the new way to get the prometheus token to not have error 


```
Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.
error: could not find a service account token for service account "prometheus-k8s"
```