### PR TITLE
Prow cerberus centos version

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -2,9 +2,9 @@
 
 FROM quay.io/openshift/origin-tests:latest as origintests
 
-FROM quay.io/centos/centos:7
+FROM quay.io/centos/centos:stream9
 
-MAINTAINER Red Hat OpenShift Performance and Scale
+LABEL maintainer="Red Hat Chaos Engineering Team"
 
 ENV KUBECONFIG /root/.kube/config
 


### PR DESCRIPTION
Want to be able to use the same base image for krkn-hub and cerberus, updating the centos image version to stream 9 

https://github.com/openshift/release/blob/9bd70917564ae6bdd0a02732a8052986d808bcb5/ci-operator/config/redhat-chaos/krkn-hub/redhat-chaos-krkn-hub-main.yaml#L5