### PR TITLE
adding output file location option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ When the cerberus is configured to run in the daemon mode, it will continuosly m
 #### Report
 The report is generated in the run directory and it contains the information about each check/monitored component status per iteration with timestamps. It also displays information about the components in case of failure. Refer [report](docs/example_report.md) for example.
 
+You can use the "-o <file_path_name>" option to change the location of the created report
+
 #### Metrics API
 Cerberus exposes the metrics including the failures observed during the run through an API. Tools consuming Cerberus can query the API to get a blob of json with the observed failures to scrape and act accordingly. For example, we can query for etcd failures within a start and end time and take actions to determine pass/fail for test cases or report whether the cluster is healthy or unhealthy for that duration.
 

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -557,11 +557,18 @@ if __name__ == "__main__":
         help="config location",
         default="config/config.yaml",
     )
+    parser.add_option(
+        "-o",
+        "--output",
+        dest="output",
+        help="output report location",
+        default="cerberus.report",
+    )
     (options, args) = parser.parse_args()
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
-        handlers=[logging.FileHandler("cerberus.report", mode="w"), logging.StreamHandler()],
+        handlers=[logging.FileHandler(options.report, mode="w"), logging.StreamHandler()],
     )
     if options.cfg is None:
         logging.error("Please check if you have passed the config")

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -568,7 +568,7 @@ if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
-        handlers=[logging.FileHandler(options.report, mode="w"), logging.StreamHandler()],
+        handlers=[logging.FileHandler(options.output, mode="w"), logging.StreamHandler()],
     )
     if options.cfg is None:
         logging.error("Please check if you have passed the config")


### PR DESCRIPTION
need to be able to set where the output file is written to based on certain permissions

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/39697/rehearse-39697-periodic-ci-redhat-chaos-krkn-hub-main-krkn-hub-tests/1671888375042281472/artifacts/krkn-hub-tests/redhat-chaos-cerberus/build-log.txt
```
+ python3 /root/cerberus/start_cerberus.py --config=/tmp/tmp.YzZXKPpakF/cerberus_config.yaml
Traceback (most recent call last):
  File "/root/cerberus/start_cerberus.py", line 557, in <module>
    handlers=[logging.FileHandler("cerberus.report", mode="w"), logging.StreamHandler()],
  File "/usr/lib64/python3.9/logging/__init__.py", line 1146, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib64/python3.9/logging/__init__.py", line 1175, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding,
PermissionError: [Errno 13] Permission denied: '/cerberus/cerberus.report'
```