### PR TITLE
Kill process default usage 

### DIFF
--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -188,6 +188,7 @@ def main(cfg):
         global time_tracker
         time_tracker = {}
 
+        global iteration
         # Initialize the start iteration to 0
         iteration = 0
 
@@ -209,6 +210,7 @@ def main(cfg):
             iterations = int(iterations)
 
         # Need to set start to cerberus_status
+        global cerberus_status
         cerberus_status = True
         # Loop to run the components status checks starts here
         while int(iteration) < iterations:
@@ -515,14 +517,6 @@ def main(cfg):
                 for operation, timing in iter_track_time.items():
                     logging.info("Time taken to run %s in iteration %s: %s seconds" % (operation, iteration, timing))
                 logging.info("----------------------------------------------------------------------\n")  # noqa
-
-            except KeyboardInterrupt:
-                pool.terminate()
-                pool.join()
-                logging.info("Terminating cerberus monitoring")
-                record_time(time_tracker)
-                print_final_status_json(iteration, cerberus_status, 1)
-                sys.exit(1)
 
             except KeyboardInterrupt:
                 pool.terminate()

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -28,8 +28,12 @@ def smap(f):
     return f()
 
 
+def handler(sig, frame):
+    raise KeyboardInterrupt("Received interrupt signal " + str(sig) + " in " + frame.f_code.co_filename)
+
+
 def init_worker():
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGINT, handler)
 
 
 # Publish the cerberus status
@@ -180,7 +184,8 @@ def main(cfg):
         # Variables used for multiprocessing
         global pool
         multiprocessing.set_start_method("fork")
-        pool = multiprocessing.Pool(int(cores_usage_percentage * multiprocessing.cpu_count()), init_worker)
+        init_worker()
+        pool = multiprocessing.Pool(int(cores_usage_percentage * multiprocessing.cpu_count()))
         manager = multiprocessing.Manager()
         pods_tracker = manager.dict()
 
@@ -517,6 +522,7 @@ def main(cfg):
                 logging.info("----------------------------------------------------------------------\n")  # noqa
 
             except KeyboardInterrupt:
+                pool.close()
                 pool.terminate()
                 pool.join()
                 logging.info("Terminating cerberus monitoring")

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -29,7 +29,7 @@ def smap(f):
 
 
 def init_worker():
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
 # Publish the cerberus status
@@ -515,6 +515,14 @@ def main(cfg):
                 for operation, timing in iter_track_time.items():
                     logging.info("Time taken to run %s in iteration %s: %s seconds" % (operation, iteration, timing))
                 logging.info("----------------------------------------------------------------------\n")  # noqa
+
+            except KeyboardInterrupt:
+                pool.terminate()
+                pool.join()
+                logging.info("Terminating cerberus monitoring")
+                record_time(time_tracker)
+                print_final_status_json(iteration, cerberus_status, 1)
+                sys.exit(1)
 
             except KeyboardInterrupt:
                 pool.terminate()

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -188,7 +188,6 @@ def main(cfg):
         global time_tracker
         time_tracker = {}
 
-        global iteration
         # Initialize the start iteration to 0
         iteration = 0
 
@@ -210,7 +209,6 @@ def main(cfg):
             iterations = int(iterations)
 
         # Need to set start to cerberus_status
-        global cerberus_status
         cerberus_status = True
         # Loop to run the components status checks starts here
         while int(iteration) < iterations:


### PR DESCRIPTION
Current signal ignores any signals being sent to start_cerberus and doesnt properly end the run  

```

If you want to ignore the signal specified by the first argument (i.e., pretending that the signal never happens), use SIG_IGN for the second argument.

    signal(SIGINT, SIG_IGN)

    signal(SIGALRM, SIG_IGN)

In the above two lines, SIGINT and SIGALRM are ignored.
``` 

switching to using: https://python.readthedocs.io/en/latest/library/signal.html#signal.SIG_DFL